### PR TITLE
style: 코인 종류 리스트 헤더 색상 변경 및 세로 길이 최대화

### DIFF
--- a/src/components/CryptoList.jsx
+++ b/src/components/CryptoList.jsx
@@ -20,7 +20,7 @@ const SelectedCoinHeader = styled.div`
   align-items: center;
   background-color: var(--hana-primary);
 
-  color: #000000;
+  color: #ffffff;
   padding: 10px;
   font-size: 12px;
 `;
@@ -28,11 +28,12 @@ const SelectedCoinHeader = styled.div`
 const CoinListContainer = styled.div`
   // border: 2px solid var(--hana-primary);
   background-color: #fff;
-  height: 180px;
+  height: 100%;
   overflow-y: auto;
 `;
 
 const CoinListUL = styled.ul`
+  height: 100%;
   list-style-type: none;
   margin: 0;
   padding: 0;


### PR DESCRIPTION
### 설명 (Description)
- 코인 종류 리스트의 헤더 글자색을 변경합니다.
- 코인 종류 리스트의 세로 길이를 최대화합니다.

### 체크리스트 (Checklist)

- [x] 코드가 성공적으로 빌드되고 모든 테스트를 통과했습니다.
- [x] 코드에 새로운 경고나 오류가 없습니다.
- [x] 코드 스타일 가이드라인을 따랐습니다.
- [ ] 필요한 문서를 업데이트했습니다.
- [x] 관련 이슈 번호를 참조했습니다. (e.g. `fixes #123`, `closes #456`)

### 변경 사항 (Changes)

- `font color` 변경
- 리스트의 `height` 속성 변경

### 관련 이슈 (Related Issues)
closes #43 

### 참고 자료 (Screenshots or References) (선택)

<img width="481" alt="image" src="https://github.com/user-attachments/assets/20fbf9c1-b1f6-4446-9f5d-58347bc3f86f" />