### PR TITLE
매수, 매도, 청산 시 안내 팝업 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react": "^19.0.0",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.0.0",
+    "sonner": "^2.0.1",
     "styled-components": "^6.1.15"
   },
   "resolutions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.0.0(react@19.0.0)
+      sonner:
+        specifier: ^2.0.1
+        version: 2.0.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       styled-components:
         specifier: ^6.1.15
         version: 6.1.15(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1287,6 +1290,12 @@ packages:
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
+
+  sonner@2.0.1:
+    resolution: {integrity: sha512-FRBphaehZ5tLdLcQ8g2WOIRE+Y7BCfWi5Zyd8bCvBjiW8TxxAyoWZIxS661Yz6TGPqFQ4VLzOF89WEYhfynSFQ==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2796,6 +2805,11 @@ snapshots:
       side-channel-list: 1.0.0
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
+
+  sonner@2.0.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
   source-map-js@1.2.1: {}
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 // Libraries
 import styled from 'styled-components';
 import { useState, useEffect } from 'react';
+import { Toaster } from 'sonner';
 
 // Utils
 import { UpbitWebSocket } from './utils/cryptoInfo';
@@ -104,6 +105,7 @@ function App() {
 
   return (
     <>
+      <Toaster position="bottom-right" />
       <Container>
         <UpperContainer>
           <LUComponent

--- a/src/components/Trade.jsx
+++ b/src/components/Trade.jsx
@@ -59,6 +59,7 @@ const Trade = ({
         quantity={quantity}
         setQuantity={setQuantity}
         handleEnter={handleEnter}
+        selectedCoinKey={selectedCoinKey}
       />
     </Container>
   );

--- a/src/components/position/PositionItem.jsx
+++ b/src/components/position/PositionItem.jsx
@@ -7,8 +7,10 @@ import styled from 'styled-components';
 
 // Components
 import PositionItemInfo from './PositionItemInfo';
+import { useToast } from '../../hooks/useToast';
 
 const PositionItem = ({ position, tradeData, balance, setBalance, positionArray, setPositionArray, setTradeDataHistory, setLogData }) => {
+  const { toast } = useToast();
   const benefit = calBenefit(position,tradeData);
   // ✅ 포지션 정리 버튼 클릭 핸들러
   const handleClosePosition = () => {
@@ -21,6 +23,10 @@ const PositionItem = ({ position, tradeData, balance, setBalance, positionArray,
     setLogData((prevLog) => [...prevLog,log]);
     //console.log(log);
     setTradeDataHistory((prevHistory) => [...prevHistory, result]);
+    toast({
+      title: `${result.coinName} ${result.orderType} ${result.quantity}개 판매 성공`,
+      description: `${benefit.toLocaleString()} ₩`,
+    });
   };
   
   return (

--- a/src/components/position/PositionItem.jsx
+++ b/src/components/position/PositionItem.jsx
@@ -24,8 +24,8 @@ const PositionItem = ({ position, tradeData, balance, setBalance, positionArray,
     //console.log(log);
     setTradeDataHistory((prevHistory) => [...prevHistory, result]);
     toast({
-      title: `${result.coinName} ${result.orderType} ${result.quantity}개 판매 성공`,
-      description: `${benefit.toLocaleString()} ₩`,
+      title: `${result.coinName} ${result.orderType} x${result.quantity} sell`,
+      description: `${benefit>0 ? '+'+benefit.toLocaleString() : benefit.toLocaleString()} ₩`,
     });
   };
   

--- a/src/components/toast/Toast.jsx
+++ b/src/components/toast/Toast.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import styled from 'styled-components';
+
+export function Toast({ title, description }) {
+  return (
+    <Container>
+      <Content>
+        <Title>{title}</Title>
+        <Description>{description}</Description>
+      </Content>
+    </Container>
+  );
+}
+
+// styled-components
+const Container = styled.div`
+  display: flex;
+  align-items: center;
+  background-color: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  padding: 16px;
+  max-width: 364px;
+  width: 100%;
+  border: 1px solid rgba(0, 0, 0, 0.05);
+`;
+
+const Content = styled.div`
+  flex: 1;
+`;
+
+const Title = styled.p`
+  font-size: 14px;
+  font-weight: 600;
+  color: #111827;
+`;
+
+const Description = styled.p`
+  margin-top: 4px;
+  font-size: 14px;
+  color: #6b7280;
+`;

--- a/src/components/toast/Toast.jsx
+++ b/src/components/toast/Toast.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
+import CornerList from '../corner/CornerList';
 
 export function Toast({ title, description }) {
   return (
@@ -8,21 +9,22 @@ export function Toast({ title, description }) {
         <Title>{title}</Title>
         <Description>{description}</Description>
       </Content>
+      <CornerList></CornerList>
     </Container>
   );
 }
 
 // styled-components
 const Container = styled.div`
+  font-family: 'Press Start 2P', 'Pixelify Sans', monospace !important;
+  padding: 16px;
+  max-width: 364px;
+  width: 100%;
+  border: 3px solid black;
   display: flex;
   align-items: center;
   background-color: white;
   border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  padding: 16px;
-  max-width: 364px;
-  width: 100%;
-  border: 1px solid rgba(0, 0, 0, 0.05);
 `;
 
 const Content = styled.div`

--- a/src/components/trade/TradeButton.jsx
+++ b/src/components/trade/TradeButton.jsx
@@ -8,10 +8,10 @@ import buySound from '@/assets/sounds/buy.mp3';
 import { lightenColor } from '../../utils/tradeUtils';
 import { useToast } from '../../hooks/useToast';
 
-const TradeButton = ({ handleEnter }) => {
+const TradeButton = ({ handleEnter, selectedCoinKey, quantity }) => {
   const sound = useRef(new Audio(buySound));
   const { toast } = useToast();
-  
+
   sound.current.currentTime = 0;
   const playSound = () => {
     sound.current.currentTime = 0;
@@ -27,7 +27,7 @@ const TradeButton = ({ handleEnter }) => {
           handleEnter('long');
           toast({
             title: '매수 체결',
-            description: '테스트',
+            description: `${selectedCoinKey} Long ${quantity}개 구매 성공`,
           });
         }}
       >

--- a/src/components/trade/TradeButton.jsx
+++ b/src/components/trade/TradeButton.jsx
@@ -26,7 +26,7 @@ const TradeButton = ({ handleEnter, selectedCoinKey, quantity }) => {
           //playSound();
           handleEnter('long');
           toast({
-            title: '매수 체결',
+            title: 'Execution',
             description: `${selectedCoinKey} Long ${quantity}개 구매 성공`,
           });
         }}
@@ -38,6 +38,10 @@ const TradeButton = ({ handleEnter, selectedCoinKey, quantity }) => {
         onClick={() => {
           //playSound();
           handleEnter('short');
+          toast({
+            title: 'Execution',
+            description: `${selectedCoinKey} Short ${quantity}개 구매 성공`,
+          });
         }}
       >
         Short

--- a/src/components/trade/TradeButton.jsx
+++ b/src/components/trade/TradeButton.jsx
@@ -6,9 +6,12 @@ import buySound from '@/assets/sounds/buy.mp3';
 
 // Utils
 import { lightenColor } from '../../utils/tradeUtils';
+import { useToast } from '../../hooks/useToast';
 
 const TradeButton = ({ handleEnter }) => {
   const sound = useRef(new Audio(buySound));
+  const { toast } = useToast();
+  
   sound.current.currentTime = 0;
   const playSound = () => {
     sound.current.currentTime = 0;
@@ -22,6 +25,10 @@ const TradeButton = ({ handleEnter }) => {
         onClick={() => {
           //playSound();
           handleEnter('long');
+          toast({
+            title: '매수 체결',
+            description: '테스트',
+          });
         }}
       >
         Long

--- a/src/components/trade/TradeButton.jsx
+++ b/src/components/trade/TradeButton.jsx
@@ -26,7 +26,7 @@ const TradeButton = ({ handleEnter, selectedCoinKey, quantity }) => {
           //playSound();
           handleEnter('long');
           toast({
-            title: `${selectedCoinKey} Long ${quantity}개 구매 성공`,
+            title: `${selectedCoinKey} Long x${quantity} buy`,
             description: '',
           });
         }}
@@ -39,7 +39,7 @@ const TradeButton = ({ handleEnter, selectedCoinKey, quantity }) => {
           //playSound();
           handleEnter('short');
           toast({
-            title: `${selectedCoinKey} Short ${quantity}개 구매 성공`,
+            title: `${selectedCoinKey} Short x${quantity} buy`,
             description: '',
           });
         }}

--- a/src/components/trade/TradeButton.jsx
+++ b/src/components/trade/TradeButton.jsx
@@ -26,8 +26,8 @@ const TradeButton = ({ handleEnter, selectedCoinKey, quantity }) => {
           //playSound();
           handleEnter('long');
           toast({
-            title: 'Execution',
-            description: `${selectedCoinKey} Long ${quantity}개 구매 성공`,
+            title: `${selectedCoinKey} Long ${quantity}개 구매 성공`,
+            description: '',
           });
         }}
       >
@@ -39,8 +39,8 @@ const TradeButton = ({ handleEnter, selectedCoinKey, quantity }) => {
           //playSound();
           handleEnter('short');
           toast({
-            title: 'Execution',
-            description: `${selectedCoinKey} Short ${quantity}개 구매 성공`,
+            title: `${selectedCoinKey} Short ${quantity}개 구매 성공`,
+            description: '',
           });
         }}
       >

--- a/src/components/trade/TradeContainer.jsx
+++ b/src/components/trade/TradeContainer.jsx
@@ -5,11 +5,11 @@ import styled from 'styled-components';
 import TradeInfo from './TradeInfo';
 import TradeButton from './TradeButton';
 
-const TradeContainer = ({ quantity, setQuantity, handleEnter }) => {
+const TradeContainer = ({ quantity, setQuantity, handleEnter, selectedCoinKey }) => {
   return (
     <Container>
       <TradeInfo quantity={quantity} setQuantity={setQuantity} />
-      <TradeButton handleEnter={handleEnter} />
+      <TradeButton handleEnter={handleEnter} selectedCoinKey={selectedCoinKey} quantity={quantity}/>
     </Container>
   );
 };

--- a/src/hooks/useToast.jsx
+++ b/src/hooks/useToast.jsx
@@ -1,0 +1,18 @@
+// hooks/useToast.ts
+import { toast as sonnerToast } from 'sonner';
+import { Toast } from '../components/toast/Toast';
+
+export function useToast() {
+  const toast = (toastData) => {
+    return sonnerToast.custom((id) => (
+      <Toast
+        id={id}
+        title={toastData.title}
+        description={toastData.description}
+        button={toastData.button}
+      />
+    ));
+  };
+
+  return { toast };
+}


### PR DESCRIPTION
### 설명 (Description)

- 매수, 매도, 청산 시 `viewport` 우측 하단에 안내 팝업이 렌더링 됩니다.
- `sonner` 라이브러리를 활용합니다.

### 체크리스트 (Checklist)

- [x] 코드가 성공적으로 빌드되고 모든 테스트를 통과했습니다.
- [x] 코드에 새로운 경고나 오류가 없습니다.
- [x] 코드 스타일 가이드라인을 따랐습니다.
- [ ] 필요한 문서를 업데이트했습니다.
- [x] 관련 이슈 번호를 참조했습니다. (e.g. `fixes #123`, `closes #456`)

### 변경 사항 (Changes)

- `buy`,` sell`, `close`의 `onClick()` 함수에 `Toast` 기능 추가

### 관련 이슈 (Related Issues)

closes #50 

### 참고 자료 (Screenshots or References) (선택)

<img width="270" alt="image" src="https://github.com/user-attachments/assets/0bb5f8d6-8a42-4db8-a11a-2983797c58bf" />
