### PR TITLE
Style: UserInfo 레이아웃 구조 변경

### DIFF
--- a/src/components/user/UserInfoDetail.jsx
+++ b/src/components/user/UserInfoDetail.jsx
@@ -7,18 +7,18 @@ const UserInfoDetail = ({title, content}) => {
   let value = content;
   switch (title) {
       case 'Deposit': {
-          value = `${content.toLocaleString('ko-KR')} ₩`;
+          value = `${content.toLocaleString('ko-KR')} KRW`;
           break;
       }
       case 'Profit': {
-          value = `${content.toLocaleString('ko-KR')} ₩`;
+          value = `${content.toLocaleString('ko-KR')} KRW`;
           break;
       }
   }
   return (
     <Container>
-        <Detail>{title} :</Detail>
-        <Detail>{value}</Detail>
+        <DetailTitle>{title}</DetailTitle>
+        <DetailValue>{value}</DetailValue>
     </Container>
   );
 };
@@ -30,15 +30,18 @@ const Container = styled.div`
   height: 100%;
   padding: 4%;
   position: relative;
-  background-color: #e9f2f1;
 
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   justify-content: space-between;
-  align-items: center;
 `;
 
-const Detail = styled.div`
+const DetailTitle = styled.div`
   display: flex;
-  align-items: center;
+  align-self: flex-start;
+`;
+
+const DetailValue = styled.div`
+  display: flex;
+  align-self: flex-end;
 `;


### PR DESCRIPTION
### 설명 (Description)

- 유저 정보 렌더링 시 글자가 넘쳐 가독성이 떨어져 레이아웃을 변경합니다.
- 한 행에 두 가지 정보를 표시하던 것에서 두 행에 나누어 정보를 표시하는 것으로 변경하였습니다.

### 체크리스트 (Checklist)

- [x] 코드가 성공적으로 빌드되고 모든 테스트를 통과했습니다.
- [x] 코드에 새로운 경고나 오류가 없습니다.
- [x] 코드 스타일 가이드라인을 따랐습니다.
- [ ] 필요한 문서를 업데이트했습니다.
- [x] 관련 이슈 번호를 참조했습니다. (e.g. `fixes #123`, `closes #456`)

### 변경 사항 (Changes)

- 한 개의 행으로 `Detail`을 렌더링 하던 것을 두 개의 행(`DetailTitle`, `DetailValue`)으로 나누었습니다. 

### 관련 이슈 (Related Issues)

#44 

### 참고 자료 (Screenshots or References) (선택)

<img width="1004" alt="image" src="https://github.com/user-attachments/assets/c62e2016-cf0a-4a99-9630-2fa8dfc65b39" />
