### PR TITLE
Style: CoinList layout을 grid로 변경

### DIFF
--- a/src/components/CryptoList.jsx
+++ b/src/components/CryptoList.jsx
@@ -45,7 +45,7 @@ const CoinListUL = styled.ul`
 `;
 
 const CoinListItem = styled.li`
-  display: flex;
+  display: grid;
   justify-content: space-between;
   align-items: center;
   padding: 10px;
@@ -53,6 +53,7 @@ const CoinListItem = styled.li`
   font-size: 10px;
   cursor: pointer;
   transition: background-color 0.1s;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
 
   &:hover {
     background-color: var(--hana-light);
@@ -65,12 +66,18 @@ const Symbol = styled.span`
 `;
 
 const Price = styled.span`
-  font-size: 9px;
+  justify-self: end;
+  text-align: right;
+  
+  font-size: clamp(4px, 2vw, 8px);
 `;
 
 const Change = styled.span`
-  font-size: 8px;
+  justify-self: end;
+  text-align: right;
   margin-left: 8px;
+  
+  font-size: clamp(4px, 2vw, 8px);
   color: ${(props) =>
     props.change === 'RISE' ? 'green' :
     props.change === 'FALL' ? 'red' :


### PR DESCRIPTION
### 설명 (Description)

- 가격 변동에 따라 `CoinList`의 레이아웃이 흔들리는 버그를 수정하기 위해 `display` 속성을 `flex`에서 `grid`로 변경합니다.

### 체크리스트 (Checklist)

- [x] 코드가 성공적으로 빌드되고 모든 테스트를 통과했습니다.
- [x] 코드에 새로운 경고나 오류가 없습니다.
- [x] 코드 스타일 가이드라인을 따랐습니다.
- [ ] 필요한 문서를 업데이트했습니다.
- [x] 관련 이슈 번호를 참조했습니다. (e.g. `fixes #123`, `closes #456`)

### 변경 사항 (Changes)
- CoinList의 flex 레이아웃인 행을 grid 레이아웃으로 변경
- 첫 번째(Symbol) 열은 왼쪽 정렬, 두 세번째 열은 오른쪽 정렬 적용

### 관련 이슈 (Related Issues)

closes #41 

### 참고 자료 (Screenshots or References) (선택)

<img width="894" alt="image" src="https://github.com/user-attachments/assets/15275b4e-051c-4992-bc02-0ba92be26f52" />
